### PR TITLE
FIX: code editor resetting cleared code to defaults

### DIFF
--- a/src/components/CodeEditorView.tsx
+++ b/src/components/CodeEditorView.tsx
@@ -456,7 +456,8 @@ const CodeEditorView = forwardRef<CodeEditorViewHandle, CodeEditorViewProps>(({
 
         // Add entries for all valid languages
         normalizedLanguages.forEach(lang => {
-            state[lang] = initial[lang] || DEFAULT_LANGUAGE_CONTENTS[lang] || '';
+            // Check if key exists to preserve empty strings when user clears code
+            state[lang] = initial[lang] !== undefined ? initial[lang] : (DEFAULT_LANGUAGE_CONTENTS[lang] || '');
         });
 
         return state;


### PR DESCRIPTION
Updated `CodeEditorView` `setupCodeState` to empty strings as valid code instead of falling back to default snippets.


https://github.com/user-attachments/assets/2a2ed3fa-9a3c-4ee8-b621-fceb10c816dd

